### PR TITLE
Simplify way app is run

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,2 +1,2 @@
-FLASK_APP=fagiolo.fagiolo.py
+FLASK_APP=fagiolo.app:app
 FLASK_ENV=development

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn fagiolo.fagiolo:app
+web: gunicorn fagiolo.app:app

--- a/fagiolo/fagiolo.py
+++ b/fagiolo/fagiolo.py
@@ -1,1 +1,0 @@
-from fagiolo.app import app  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 import pytest
 from flask.testing import FlaskClient
 
-from fagiolo import fagiolo
+from fagiolo.app import app
 
 
 @pytest.fixture
 def client() -> FlaskClient:
-    fagiolo.app.config["DEBUG"] = True
-    fagiolo.app.config["TESTING"] = True
-    fagiolo.app.config["PROPAGATE_EXCEPTIONS"] = False
-    fagiolo.app.config["PRESERVE_CONTEXT_ON_EXCEPTION"] = False
+    app.config["DEBUG"] = True
+    app.config["TESTING"] = True
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    app.config["PRESERVE_CONTEXT_ON_EXCEPTION"] = False
 
-    with fagiolo.app.test_client() as client:
+    with app.test_client() as client:
         yield client


### PR DESCRIPTION
Simplify way app is run by deleting the `fagiolo.py` module that imports `app`, and just calling `app` from `fagiolo/app/__init__.py` directly