### PR TITLE
Add preload flag to gunicorn command to show logs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn fagiolo.app:app
+web: gunicorn fagiolo.app:app --preload


### PR DESCRIPTION
The deployment is rolling out successfully on Heroku, but the app fails. The logs don't show why, so I'm adding `--preload` to the `gunicorn` command, which should give more info to stdout.